### PR TITLE
Split SPI update from setVoltage()

### DIFF
--- a/MCPDAC.cpp
+++ b/MCPDAC.cpp
@@ -27,10 +27,6 @@ void MCPDACClass::begin(uint8_t cspin)
 {
 	this->ldac = false;
 	this->cspin = cspin;
-	this->shdn[CHANNEL_A] = false;
-	this->shdn[CHANNEL_B] = false;
-	this->gain[CHANNEL_A] = GAIN_LOW;
-	this->gain[CHANNEL_B] = GAIN_LOW;
 	pinMode(this->cspin,OUTPUT);
 	digitalWrite(this->cspin,HIGH);
 	SPI.begin();
@@ -55,19 +51,9 @@ void MCPDACClass::shutdown(bool chan, bool sd)
 	this->shdn[chan] = sd;
 }
 
-void MCPDACClass::setVoltage(bool channel, uint16_t mv)
+void MCPDACClass::setVoltage(bool chan, uint16_t mv)
 {
-	uint16_t command = 0;
-	command |= (channel << REGAB);                 // set channel in register
-	command |= (!this->gain[channel] << REGGA);    // set gain in register
-	command |= (!this->shdn[channel] << REGSHDN);  // set shutdown in register
-	command |= (mv & 0x0FFF);                      // set input data bits (strip everything greater than 12 bit)
-
-	SPI.setDataMode(SPI_MODE0);
-	digitalWrite(this->cspin,LOW);
-	SPI.transfer(command>>8);
-	SPI.transfer(command&0xFF);
-	digitalWrite(this->cspin,HIGH);
+	this->value[chan] = mv;
 }
 
 void MCPDACClass::update()
@@ -76,4 +62,19 @@ void MCPDACClass::update()
 		return;
 	digitalWrite(this->ldacpin,LOW);
 	digitalWrite(this->ldacpin,HIGH);
+}
+
+void MCPDACClass::updateRegister(bool chan)
+{
+	uint16_t command = 0;
+	command |= (chan << REGAB);                 // set channel in register
+	command |= (!this->gain[chan] << REGGA);    // set gain in register
+	command |= (!this->shdn[chan] << REGSHDN);  // set shutdown in register
+	command |= (this->value[chan] & 0x0FFF);                      // set input data bits (strip everything greater than 12 bit)
+
+	SPI.setDataMode(SPI_MODE0);
+	digitalWrite(this->cspin,LOW);
+	SPI.transfer(command>>8);
+	SPI.transfer(command&0xFF);
+	digitalWrite(this->cspin,HIGH);
 }

--- a/MCPDAC.cpp
+++ b/MCPDAC.cpp
@@ -54,6 +54,7 @@ void MCPDACClass::shutdown(bool chan, bool sd)
 void MCPDACClass::setVoltage(bool chan, uint16_t mv)
 {
 	this->value[chan] = mv;
+	this->updateRegister(chan);
 }
 
 void MCPDACClass::update()

--- a/MCPDAC.h
+++ b/MCPDAC.h
@@ -24,11 +24,12 @@
 class MCPDACClass {
 
 	private:
-		bool ldac;
+		bool ldac = false;
 		bool gain[2] = { GAIN_LOW, GAIN_LOW };
 		bool shdn[2] = { true, true };
+    uint16_t value[2] = { 0, 0 };
 		uint8_t cspin;
-		uint8_t ldacpin;
+		uint8_t ldacpin = 0;
 
 	public:
 		void begin();
@@ -36,8 +37,9 @@ class MCPDACClass {
 		void begin(uint8_t cspin, uint8_t ldacpin);
 		void setGain(bool chan, bool gain);
 		void shutdown(bool chan, bool sd);
-		void setVoltage(bool channel, uint16_t mv);
+		void setVoltage(bool chan, uint16_t mv);
 		void update();
+		void updateRegister(bool chan);
 };
 
 extern MCPDACClass MCPDAC;


### PR DESCRIPTION
Thanks for accepting the last pull request. Since you so happily accepted it, here is another useful thing. Or at least I wanted it.

Moved SPI code from setVoltage() to its own function updateRegister(). This way shutting down the DAC can be done without having to use setVoltage().

I left a call to updateRegister() inside setVoltage() for backwards compatibility. But in non-latch mode this will update the DAC as soon as setVoltage() is called. Fine for my case. And I rather not break backwards compatibility.

And I also updated local variables to always be chan (instead of channel inside setVoltage()).